### PR TITLE
:sparkles: Adapt to fzf-tmux to widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ bindkey '^x^g' fzf-ghq
 bindkey '^x^v' fzf-grep-vscode
 ```
 
+To use normal fzf in tmux session, set `FZF_TMUX_DISABLED` to 1.
 To disable this setting, set FZF_PREVIEW_DISABLE_DEFAULT_BIND to 1.
 
 ## Requirements

--- a/src/widget/fzf-cd
+++ b/src/widget/fzf-cd
@@ -1,7 +1,12 @@
 #autoload
 
 local fd_command="fd . --color=always --type=d"
-local fzf_command="fzf --ansi --preview='exa --color=always --tree {}'"
+local fzf_options_=" --ansi --preview='exa --color=always --tree {}'"
+if [[ $TMUX ]]; then
+  local fzf_command="fzf-tmux'${fzf_options_}'"
+else
+  local fzf_command="fzf'${fzf_options_}'"
+fi
 fzf_command+=" ${FZF_PREVIEW_DEFAULT_SETTING}"
 fzf_command+=" --bind='${FZF_PREVIEW_DEFAULT_BIND}'"
 local command="${fd_command} | ${fzf_command}"

--- a/src/widget/fzf-cd
+++ b/src/widget/fzf-cd
@@ -2,7 +2,7 @@
 
 local fd_command="fd . --color=always --type=d"
 local fzf_options_=" --ansi --preview='exa --color=always --tree {}'"
-if [[ $TMUX ]]; then
+if [[ $TMUX && ! $FZF_TMUX_DISABLED = 1 ]]; then
   local fzf_command="fzf-tmux'${fzf_options_}'"
 else
   local fzf_command="fzf'${fzf_options_}'"

--- a/src/widget/fzf-ghq
+++ b/src/widget/fzf-ghq
@@ -1,7 +1,12 @@
 #autoload
 
 local ghq_command="ghq list -p | sed -e \"s|$HOME|~|\""
-local fzf_command="fzf --preview='eval bat --color=always {}/README.md 2>/dev/null'"
+local fzf_options_="fzf --preview='eval bat --color=always {}/README.md 2>/dev/null'"
+if [[ $TMUX ]]; then
+  local fzf_command="fzf-tmux'${fzf_options_}'"
+else
+  local fzf_command="fzf'${fzf_options_}'"
+fi
 fzf_command+=" ${FZF_PREVIEW_DEFAULT_SETTING}"
 fzf_command+=" --bind='${FZF_PREVIEW_DEFAULT_BIND}'"
 local command="${ghq_command} | ${fzf_command}"

--- a/src/widget/fzf-ghq
+++ b/src/widget/fzf-ghq
@@ -2,7 +2,7 @@
 
 local ghq_command="ghq list -p | sed -e \"s|$HOME|~|\""
 local fzf_options_="fzf --preview='eval bat --color=always {}/README.md 2>/dev/null'"
-if [[ $TMUX ]]; then
+if [[ $TMUX && ! $FZF_TMUX_DISABLED = 1 ]]; then
   local fzf_command="fzf-tmux'${fzf_options_}'"
 else
   local fzf_command="fzf'${fzf_options_}'"

--- a/src/widget/fzf-grep-vscode
+++ b/src/widget/fzf-grep-vscode
@@ -2,7 +2,7 @@
 
 local grep_command='rg --line-number --no-heading .'
 local fzf_options_="fzf ${FZF_PREVIEW_DEFAULT_SETTING} --bind='${FZF_PREVIEW_DEFAULT_BIND}' --ansi --multi --prompt='VSCode> ' --delimiter=':' --nth=3 --preview='${FZF_PREVIEW_BIN_PATH}/preview_fzf_grep {}' | cut -d':' -f1-2 2>/dev/null"
-if [[ $TMUX ]]; then
+if [[ $TMUX && ! $FZF_TMUX_DISABLED = 1 ]]; then
   local fzf_command="fzf-tmux'${fzf_options_}'"
 else
   local fzf_command="fzf'${fzf_options_}'"

--- a/src/widget/fzf-grep-vscode
+++ b/src/widget/fzf-grep-vscode
@@ -1,7 +1,12 @@
 #autoload
 
 local grep_command='rg --line-number --no-heading .'
-local fzf_command="fzf ${FZF_PREVIEW_DEFAULT_SETTING} --bind='${FZF_PREVIEW_DEFAULT_BIND}' --ansi --multi --prompt='VSCode> ' --delimiter=':' --nth=3 --preview='${FZF_PREVIEW_BIN_PATH}/preview_fzf_grep {}' | cut -d':' -f1-2 2>/dev/null"
+local fzf_options_="fzf ${FZF_PREVIEW_DEFAULT_SETTING} --bind='${FZF_PREVIEW_DEFAULT_BIND}' --ansi --multi --prompt='VSCode> ' --delimiter=':' --nth=3 --preview='${FZF_PREVIEW_BIN_PATH}/preview_fzf_grep {}' | cut -d':' -f1-2 2>/dev/null"
+if [[ $TMUX ]]; then
+  local fzf_command="fzf-tmux'${fzf_options_}'"
+else
+  local fzf_command="fzf'${fzf_options_}'"
+fi
 local vscode_command='xargs -I{} sh -c "code --reuse-window --goto {}; sleep 1t pu"'
 local command="${grep_command} | ${fzf_command} | ${vscode_command}"
 

--- a/src/widget/fzf-history-selection
+++ b/src/widget/fzf-history-selection
@@ -1,6 +1,10 @@
 #autoload
 
-local history=$(\history -n -r 1 | fzf --no-sort --query="'$LBUFFER" --prompt="History> ")
+if [[ $TMUX ]]; then
+  local history=$(\history -n -r 1 | fzf-tmux --no-sort --query="'$LBUFFER" --prompt="History> ")
+else
+  local history=$(\history -n -r 1 | fzf --no-sort --query="'$LBUFFER" --prompt="History> ")
+fi
 if [[ $history != "" ]]; then
   BUFFER=$history
   CURSOR=$#BUFFER

--- a/src/widget/fzf-history-selection
+++ b/src/widget/fzf-history-selection
@@ -1,6 +1,6 @@
 #autoload
 
-if [[ $TMUX ]]; then
+if [[ $TMUX && ! $FZF_TMUX_DISABLED = 1 ]]; then
   local history=$(\history -n -r 1 | fzf-tmux --no-sort --query="'$LBUFFER" --prompt="History> ")
 else
   local history=$(\history -n -r 1 | fzf --no-sort --query="'$LBUFFER" --prompt="History> ")


### PR DESCRIPTION
- Feature: Using fzf-tmux if you're in tmux session
  - Available widgets is fzf-cd, fzf-ghq, fzf-grep-vscode, and fzf-history-selection.
- Undone: Adapting fzf command to tab completion
  - Because it looks like they call "\_fzf\_complete" in scripts under "config". I couldn't find how to adjust it to tmux-git.
