### PR TITLE
Fix widget `fzf-ghq` not working

### DIFF
--- a/src/widget/fzf-ghq
+++ b/src/widget/fzf-ghq
@@ -1,11 +1,11 @@
 #autoload
 
 local ghq_command="ghq list -p | sed -e \"s|$HOME|~|\""
-local fzf_options_="fzf --preview='eval bat --color=always {}/README.md 2>/dev/null'"
+local fzf_options_="--preview='eval bat --color=always {}/README.md 2>/dev/null'"
 if [[ $TMUX && $FZF_PREVIEW_ENABLE_TMUX = 1 ]]; then
-  local fzf_command="fzf-tmux'${fzf_options_}'"
+  local fzf_command="fzf-tmux ${fzf_options_}"
 else
-  local fzf_command="fzf'${fzf_options_}'"
+  local fzf_command="fzf ${fzf_options_}"
 fi
 fzf_command+=" ${FZF_PREVIEW_DEFAULT_SETTING}"
 fzf_command+=" --bind='${FZF_PREVIEW_DEFAULT_BIND}'"

--- a/src/widget/fzf-ghq
+++ b/src/widget/fzf-ghq
@@ -15,4 +15,5 @@ local dir=$(eval $command)
 
 if [[ $dir != "" ]]; then
   eval cd $dir
+  zle accept-line
 fi


### PR DESCRIPTION
## Summary

Press `^x^g` doesn't working fzf-ghq.

All it does is reset the prompt and it doesn't do anything.

After the fix, the prompts are no longer reset, so I fixed it.